### PR TITLE
Optimized docker images

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -1,22 +1,21 @@
-FROM bitnami/minideb:wheezy
+FROM bitnami/minideb:jessie
 
-RUN install_packages ca-certificates curl make
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update -qq && apt-get install -y locales -qq && locale-gen en_US.UTF-8 en_us && dpkg-reconfigure locales && dpkg-reconfigure locales && locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
-ENV LC_ALL C.UTF-8
+RUN install_packages ca-certificates locales make curl
+RUN locale-gen C.UTF-8 && update-locale LANG=C.UTF-8
+ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
-RUN dpkg -i erlang-solutions_1.0_all.deb
-RUN rm erlang-solutions_1.0_all.deb
+RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
+	&& dpkg -i erlang-solutions_1.0_all.deb \
+	&& rm erlang-solutions_1.0_all.deb
 
-RUN apt-get update
 RUN install_packages erlang-base erlang-dev erlang-syntax-tools erlang-parsetools erlang-ssl erlang-inets
 
-RUN curl https://codeload.github.com/elixir-lang/elixir/tar.gz/v1.2.6 -o "elixir-1.2.6.tar.gz"
-RUN tar xzvf elixir-1.2.6.tar.gz
-RUN cd elixir-1.2.6 && make clean compile install
-RUN cd .. && rm -rf elixir*
+RUN curl https://codeload.github.com/elixir-lang/elixir/tar.gz/v1.2.6 -o "elixir-1.2.6.tar.gz" \
+	&& tar xzvf elixir-1.2.6.tar.gz \
+	&& cd elixir-1.2.6 \
+	&& make clean compile install \
+	&& cd .. \
+	&& rm -rf elixir* \
+	&& apt-get purge -y --auto-remove curl make
 
 CMD ["iex"]

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -1,22 +1,21 @@
 FROM bitnami/minideb:jessie
 
-RUN install_packages ca-certificates curl make
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update -qq && apt-get install -y locales -qq && locale-gen en_US.UTF-8 en_us && dpkg-reconfigure locales && dpkg-reconfigure locales && locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
-ENV LC_ALL C.UTF-8
+RUN install_packages ca-certificates locales make curl
+RUN locale-gen C.UTF-8 && update-locale LANG=C.UTF-8
+ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
-RUN dpkg -i erlang-solutions_1.0_all.deb
-RUN rm erlang-solutions_1.0_all.deb
+RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
+	&& dpkg -i erlang-solutions_1.0_all.deb \
+	&& rm erlang-solutions_1.0_all.deb
 
-RUN apt-get update
 RUN install_packages erlang-base erlang-dev erlang-syntax-tools erlang-parsetools erlang-ssl erlang-inets
 
-RUN curl https://codeload.github.com/elixir-lang/elixir/tar.gz/v1.3.4 -o "elixir-1.3.4.tar.gz"
-RUN tar xzvf elixir-1.3.4.tar.gz
-RUN cd elixir-1.3.4 && make clean compile install
-RUN cd .. && rm -rf elixir*
+RUN curl https://codeload.github.com/elixir-lang/elixir/tar.gz/v1.3.4 -o "elixir-1.3.4.tar.gz" \
+	&& tar xzvf elixir-1.3.4.tar.gz \
+	&& cd elixir-1.3.4 \
+	&& make clean compile install \
+	&& cd .. \
+	&& rm -rf elixir* \
+	&& apt-get purge -y --auto-remove curl make
 
 CMD ["iex"]

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,22 +1,21 @@
 FROM bitnami/minideb:jessie
 
-RUN install_packages ca-certificates curl make
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update -qq && apt-get install -y locales -qq && locale-gen en_US.UTF-8 en_us && dpkg-reconfigure locales && dpkg-reconfigure locales && locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
-ENV LC_ALL C.UTF-8
+RUN install_packages ca-certificates locales make curl
+RUN locale-gen C.UTF-8 && update-locale LANG=C.UTF-8
+ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
-RUN dpkg -i erlang-solutions_1.0_all.deb
-RUN rm erlang-solutions_1.0_all.deb
+RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
+	&& dpkg -i erlang-solutions_1.0_all.deb \
+	&& rm erlang-solutions_1.0_all.deb
 
-RUN apt-get update
 RUN install_packages erlang-base erlang-dev erlang-syntax-tools erlang-parsetools erlang-ssl erlang-inets
 
-RUN curl https://codeload.github.com/elixir-lang/elixir/tar.gz/v1.4.0 -o "elixir-1.4.0.tar.gz"
-RUN tar xzvf elixir-1.4.0.tar.gz
-RUN cd elixir-1.4.0 && make clean compile install
-RUN cd .. && rm -rf elixir*
+RUN curl https://codeload.github.com/elixir-lang/elixir/tar.gz/v1.4.0 -o "elixir-1.4.0.tar.gz" \
+	&& tar xzvf elixir-1.4.0.tar.gz \
+	&& cd elixir-1.4.0 \
+	&& make clean compile install \
+	&& cd .. \
+	&& rm -rf elixir* \
+	&& apt-get purge -y --auto-remove curl make
 
 CMD ["iex"]


### PR DESCRIPTION
Less layers and less image size. I tested this only briefly by verifying that `docker run -it z0rc/minideb-elixir:1.4` gives working REPL.
```
% docker images
REPOSITORY                            TAG                 IMAGE ID            CREATED             SIZE
z0rc/minideb-elixir                   1.2                 9ec946ab9d86        2 minutes ago       115.4 MB
z0rc/minideb-elixir                   1.3                 4d7b9cf950e8        7 minutes ago       115.9 MB
z0rc/minideb-elixir                   1.4                 2f5c12100a04        About an hour ago   116.2 MB
```